### PR TITLE
- fixed missing migration

### DIFF
--- a/app/src/main/java/es/jvbabi/vplanplus/data/source/database/dao/ProfileDao.kt
+++ b/app/src/main/java/es/jvbabi/vplanplus/data/source/database/dao/ProfileDao.kt
@@ -30,7 +30,7 @@ abstract class ProfileDao {
     @Query("DELETE FROM profile WHERE profileId = :profileId")
     abstract suspend fun deleteProfile(profileId: UUID)
 
-    @Query("SELECT * FROM profile WHERE (type = 1 AND referenceId IN (SELECT id FROM school_entity WHERE schoolId = :schoolId))")
+    @Query("SELECT * FROM profile WHERE referenceId IN (SELECT id FROM school_entity WHERE schoolId = :schoolId)")
     @Transaction
     abstract suspend fun getProfilesBySchoolId(schoolId: Long): List<CProfile>
 }


### PR DESCRIPTION
Caused by migration to school entity, query had an relict filter from when it was necessary to check the profile type to filter in the correct table